### PR TITLE
Added Feature to display Node Allocation through Gauge Chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "msw": "^0.42.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-google-charts": "^4.0.0",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.6.4",
@@ -14735,6 +14736,15 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-google-charts": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.0.tgz",
+      "integrity": "sha512-9OG0EkBb9JerKEPQYdhmAXnhGLzOdOHOPS9j7l+P1a3z1kcmq9mGDa7PUoX/VQUY4IjZl2/81nsO4o+1cuYsuw==",
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -27874,6 +27884,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-google-charts": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.0.tgz",
+      "integrity": "sha512-9OG0EkBb9JerKEPQYdhmAXnhGLzOdOHOPS9j7l+P1a3z1kcmq9mGDa7PUoX/VQUY4IjZl2/81nsO4o+1cuYsuw==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@mui/icons-material": "^5.8.0",
     "@mui/material": "^5.8.0",
     "@svgr/webpack": "^6.2.1",
+    "react-google-charts": "^4.0.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/ClusterDetail/ClusterDetail.tsx
+++ b/src/ClusterDetail/ClusterDetail.tsx
@@ -7,7 +7,6 @@ import GameServerBuildTable from "./GameServerBuildTable";
 import NodeTable from "../Common/NodeTable";
 import { GameServer, GameServerBuild } from "../types";
 import { fetchWithTimeout } from "../utils";
-import NodeMetricsSummary from "../Common/NodeMetricsSummary";
 
 interface ClusterDetailProps {
   clusters: Record<string, Record<string, string>>

--- a/src/ClusterDetail/ClusterDetail.tsx
+++ b/src/ClusterDetail/ClusterDetail.tsx
@@ -7,6 +7,7 @@ import GameServerBuildTable from "./GameServerBuildTable";
 import NodeTable from "../Common/NodeTable";
 import { GameServer, GameServerBuild } from "../types";
 import { fetchWithTimeout } from "../utils";
+import NodeMetricsSummary from "../Common/NodeMetricsSummary";
 
 interface ClusterDetailProps {
   clusters: Record<string, Record<string, string>>

--- a/src/Common/NodeMetricsSummary.tsx
+++ b/src/Common/NodeMetricsSummary.tsx
@@ -5,7 +5,7 @@ interface NodeMetrics {
     name: string;
     cpu?: number;
     memory?: number;
-    capacity?: number;
+    allocation?: number;
 }
 
 const options1 = {
@@ -37,7 +37,7 @@ function NodeMetricsSummary(props: NodeMetrics) {
             <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                 { props.cpu && <Chart chartType='Gauge' data={[["Label", "Value"],["Memory", props.cpu]]} options={options1} />}
                 { props.memory && <Chart chartType='Gauge' data={[["Label", "Value"],["Memory", props.memory]]} options={options1} />}
-                { props.capacity !== undefined && <Chart chartType='Gauge' data={[["Label", "Value"],["Capacity", props.capacity]]} options={options2} />}
+                { props.allocation !== undefined && <Chart chartType='Gauge' data={[["Label", "Value"],["Allocation", props.allocation]]} options={options2} />}
             </div>
         </>
     )

--- a/src/Common/NodeMetricsSummary.tsx
+++ b/src/Common/NodeMetricsSummary.tsx
@@ -1,0 +1,46 @@
+import { Typography } from '@mui/material';
+import { Chart } from 'react-google-charts';
+
+interface NodeMetrics {
+    name: string;
+    cpu?: number;
+    memory?: number;
+    capacity?: number;
+}
+
+const options1 = {
+    width: 200,
+    height: 150,
+    redFrom: 90,
+    redTo: 100,
+    yellowFrom: 75,
+    yellowTo: 90,
+    minorTicks: 5,
+  };
+
+  const options2 = {
+    width: 200,
+    height: 150,
+    redFrom: 0,
+    redTo: 10,
+    yellowFrom: 10,
+    yellowTo: 25,
+    minorTicks: 5,
+  };
+
+function NodeMetricsSummary(props: NodeMetrics) {
+    return (
+        <>
+            <Typography style={{ marginTop: '20px' }} variant="h5" gutterBottom component="div">
+              Metrics
+            </Typography>
+            <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                { props.cpu && <Chart chartType='Gauge' data={[["Label", "Value"],["Memory", props.cpu]]} options={options1} />}
+                { props.memory && <Chart chartType='Gauge' data={[["Label", "Value"],["Memory", props.memory]]} options={options1} />}
+                { props.capacity !== undefined && <Chart chartType='Gauge' data={[["Label", "Value"],["Capacity", props.capacity]]} options={options2} />}
+            </div>
+        </>
+    )
+}
+
+export default NodeMetricsSummary;

--- a/src/Common/NodeTable.tsx
+++ b/src/Common/NodeTable.tsx
@@ -54,7 +54,7 @@ function NodeTable({ nodeData }: NodeTableProps) {
       <Collapse unmountOnExit in={!!selectedNode}>
         {selectedNode && <NodeMetricsSummary 
           name={selectedNode.name} 
-          capacity={selectedNode.metrics.active === 0 && selectedNode.metrics.standingBy === 0 ? 0 : (selectedNode.metrics.standingBy*100)/(selectedNode.metrics.active + selectedNode.metrics.standingBy)}
+          allocation={selectedNode.metrics.active === 0 && selectedNode.metrics.standingBy === 0 ? 0 : (selectedNode.metrics.active*100)/(selectedNode.metrics.active + selectedNode.metrics.standingBy)}
           />}
       </Collapse>
     </>

--- a/src/Common/NodeTable.tsx
+++ b/src/Common/NodeTable.tsx
@@ -16,16 +16,17 @@ interface NodeMetricsInfo {
 
 function NodeTable({ nodeData }: NodeTableProps) {
   const [selectedNode, setSelectedNode] = useState<NodeMetricsInfo | undefined>(undefined);
-  const toggleSelectedNode = (nodeToggled: string, data: Record<string, number>) => {
-    if (selectedNode && nodeToggled === selectedNode.name) {
-      setSelectedNode(undefined);
-      return;
-    }
-    setSelectedNode({ name: nodeToggled, metrics: data });
-  }
-  
+
   const items = useMemo(() => {
     const nodeNames = Object.keys(nodeData).sort();
+    const toggleSelectedNode = (nodeToggled: string, data: Record<string, number>) => {
+      if (selectedNode && nodeToggled === selectedNode.name) {
+        setSelectedNode(undefined);
+        return;
+      }
+      setSelectedNode({ name: nodeToggled, metrics: data });
+    }
+
     return nodeNames.map((nodeName, index) => <NodeTableItem 
                                                 key={index} 
                                                 selectedNode={selectedNode?.name} 

--- a/src/Common/NodeTable.tsx
+++ b/src/Common/NodeTable.tsx
@@ -1,32 +1,62 @@
-import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from "@mui/material";
-import { useMemo } from "react";
+import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, Collapse } from "@mui/material";
+import { useMemo, useState } from "react";
+import NodeMetricsSummary from "./NodeMetricsSummary";
 import NodeTableItem from "./NodeTableItem";
 
 interface NodeTableProps {
   nodeData: Record<string, Record<string, number>>
 }
 
+interface NodeMetricsInfo {
+  name: string,
+  metrics: {
+    [name: string]: number
+  }
+};
+
 function NodeTable({ nodeData }: NodeTableProps) {
+  const [selectedNode, setSelectedNode] = useState<NodeMetricsInfo | undefined>(undefined);
+  const toggleSelectedNode = (nodeToggled: string, data: Record<string, number>) => {
+    if (selectedNode && nodeToggled === selectedNode.name) {
+      setSelectedNode(undefined);
+      return;
+    }
+    setSelectedNode({ name: nodeToggled, metrics: data });
+  }
+  
   const items = useMemo(() => {
     const nodeNames = Object.keys(nodeData).sort();
-    return nodeNames.map((nodeName, index) => <NodeTableItem key={index} nodeName={nodeName} values={nodeData[nodeName]} />);
-  }, [nodeData]);
+    return nodeNames.map((nodeName, index) => <NodeTableItem 
+                                                key={index} 
+                                                selectedNode={selectedNode?.name} 
+                                                onNodeSelected={toggleSelectedNode} 
+                                                nodeName={nodeName} 
+                                                values={nodeData[nodeName]} />);
+  }, [nodeData, selectedNode]);
 
   return (
-    <TableContainer component={Paper}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Node name</TableCell>
-            <TableCell>Active</TableCell>
-            <TableCell>StandingBy</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {items}
-        </TableBody>
-      </Table>
-    </TableContainer>
+    <>
+      <TableContainer component={Paper}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Node name</TableCell>
+              <TableCell>Active</TableCell>
+              <TableCell>StandingBy</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      <Collapse unmountOnExit in={!!selectedNode}>
+        {selectedNode && <NodeMetricsSummary 
+          name={selectedNode.name} 
+          capacity={selectedNode.metrics.active === 0 && selectedNode.metrics.standingBy === 0 ? 0 : (selectedNode.metrics.standingBy*100)/(selectedNode.metrics.active + selectedNode.metrics.standingBy)}
+          />}
+      </Collapse>
+    </>
   );
 }
 

--- a/src/Common/NodeTableItem.tsx
+++ b/src/Common/NodeTableItem.tsx
@@ -1,4 +1,4 @@
-import { Chip, TableCell, TableRow } from "@mui/material";
+import { Box, Chip, TableCell, TableRow } from "@mui/material";
 import React from "react";
 
 interface NodeTableItemProps {
@@ -13,10 +13,19 @@ function NodeTableItem({ nodeName, values, onNodeSelected, selectedNode }: NodeT
   const [isHovered, setIsHovered] = React.useState(false);
   return (
     <TableRow sx={[{ '&:hover': { cursor: 'pointer' } }]} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)} hover selected={nodeName === selectedNode} onClick={() => onNodeSelected(nodeName, values)}>
-        <TableCell style={{ display: 'flex', alignItems: 'center', width: '250px'}}>
+
+      <TableCell style={{ display: 'flex', alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gap: 0,
+            gridTemplateColumns: 'repeat(2, 1fr)',
+          }}
+        >
           <span style={{ marginRight: '5px' }}>{nodeName}</span>
-          { (isHovered || nodeName === selectedNode) && <Chip sx={{ fontSize: 'x-small' }} label="View Metrics" size="small" />} 
-        </TableCell>
+          { (isHovered || nodeName === selectedNode) && <Chip sx={{ fontSize: 'x-small', '&:hover': { cursor: 'pointer' } }} label="View Metrics" size="small" />} 
+        </Box>
+      </TableCell> 
         <TableCell>{values.active}</TableCell>
         <TableCell>{values.standingBy}</TableCell>
       </TableRow>

--- a/src/Common/NodeTableItem.tsx
+++ b/src/Common/NodeTableItem.tsx
@@ -1,14 +1,22 @@
-import { TableCell, TableRow } from "@mui/material";
+import { Chip, TableCell, TableRow } from "@mui/material";
+import React from "react";
 
 interface NodeTableItemProps {
   nodeName: string,
-  values: Record<string, number>
+  values: Record<string, number>,
+  selectedNode?: string,
+  onNodeSelected: (name: string, data: Record<string, number>) => void
 }
 
-function NodeTableItem({ nodeName, values }: NodeTableItemProps) {
+
+function NodeTableItem({ nodeName, values, onNodeSelected, selectedNode }: NodeTableItemProps) {
+  const [isHovered, setIsHovered] = React.useState(false);
   return (
-    <TableRow>
-        <TableCell>{nodeName}</TableCell>
+    <TableRow sx={[{ '&:hover': { cursor: 'pointer' } }]} onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)} hover selected={nodeName === selectedNode} onClick={() => onNodeSelected(nodeName, values)}>
+        <TableCell style={{ display: 'flex', alignItems: 'center', width: '250px'}}>
+          <span style={{ marginRight: '5px' }}>{nodeName}</span>
+          { (isHovered || nodeName === selectedNode) && <Chip sx={{ fontSize: 'x-small' }} label="View Metrics" size="small" />} 
+        </TableCell>
         <TableCell>{values.active}</TableCell>
         <TableCell>{values.standingBy}</TableCell>
       </TableRow>


### PR DESCRIPTION
Screenshot of the Feature below
Component can also display Gauge Charts for Memory and CPU if props are provided.

@javier-op / @dgkanatsios  let me know if anything else needs to be done here :)

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/23561858/191675365-1495faf8-5ff6-49bc-b07d-4b36abd8f289.png">
